### PR TITLE
Add status package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/dadosjusbr/executor
 
 go 1.13
-
-require github.com/dadosjusbr/coletores v0.0.0-20200610111150-1b119ef811e2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/dadosjusbr/coletores v0.0.0-20200610111150-1b119ef811e2 h1:D+E9Qpg9uDWaxghwKJbmfMocL5m4vTduOLyMIFJq2YA=
-github.com/dadosjusbr/coletores v0.0.0-20200610111150-1b119ef811e2/go.mod h1:gO+iQtyiT9Hw1piAtdGVnfUQNsowQ5zNkuX2fBfTEqE=

--- a/pipeline.go
+++ b/pipeline.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dadosjusbr/coletores/status"
+	"github.com/dadosjusbr/executor/status"
 )
 
 const noExitError = -2

--- a/status/README.md
+++ b/status/README.md
@@ -12,7 +12,7 @@ Abaixo segue uma tabela com os status disponíveis:
 |InvalidParameters|Deve ser utilizado em caso de parâmetros inválidos, como ano e mês.|
 |SystemError|Deve ser usado em casos como falha ao criar o diretório dos arquivos ou na leitura de arquivos.|
 |ConnectionError|Deve ser usado em problemas de conexão, como timeout ou serviço fora do ar.|
-|DataUnavailable|A informação solicitada não foi encontrada, provavelmente o órgão não o disponibiliou ainda.|
+|DataUnavailable|A informação solicitada não foi encontrada, provavelmente o órgão não disponibilizou ainda.|
 |InvalidFile| Deve ser usado para cenários onde o arquivo não é o esperado ou em caso de falhas na extração de dados.|
 |Unexpected|Deve ser usando quando um erro inesperado ocorrer.|
 ______________

--- a/status/README.md
+++ b/status/README.md
@@ -1,0 +1,18 @@
+# Status Package
+
+Esse pacote tem o objetivo de padronizar os status de execução dos coletores. O Pacote foi originalmente desenvolvido no [Dadosjusbr/Coletores](https://github.com/dadosjusbr/coletores), e foi copiado, parcialmente, para cá por conta da transição da funcionalidade de execução dos coletores.
+
+## Status disponíveis
+
+Abaixo segue uma tabela com os status disponíveis:
+
+| Status code | Significado |
+--------------|----------
+|OK| O processo ocorreu sem erros.|
+|InvalidParameters|Deve ser utilizado em caso de parâmetros inválidos, como ano e mês.|
+|SystemError|Deve ser usado em casos como falha ao criar o diretório dos arquivos ou na leitura de arquivos.|
+|ConnectionError|Deve ser usado em problemas de conexão, como timeout ou serviço fora do ar.|
+|DataUnavailable|A informação solicitada não foi encontrada, provavelmente o órgão não o disponibiliou ainda.|
+|InvalidFile| Deve ser usado para cenários onde o arquivo não é o esperado ou em caso de falhas na extração de dados.|
+|Unexpected|Deve ser usando quando um erro inesperado ocorrer.|
+______________

--- a/status/status.go
+++ b/status/status.go
@@ -1,0 +1,45 @@
+package status
+
+// Code is a custom type to represent ints
+type Code int
+
+const (
+	// OK means that the process worked without errors
+	OK Code = 0
+
+	// InvalidParameters should be used for scenarios where month and year are not valid
+	InvalidParameters Code = 1
+
+	// SystemError should be used for scenarios like i/o erros, for example a failure on opening a file
+	SystemError Code = 2
+
+	// ConnectionError should be used for scenarios with connection problems, like timeouts or service unavailable
+	ConnectionError Code = 3
+
+	// DataUnavailable means that the desired data was not found on crawling
+	DataUnavailable Code = 4
+
+	//InvalidFile should be used for invalid files or for scenarios where some data could not be extracted
+	InvalidFile Code = 5
+
+	// Unknown means that something unexpected has happend
+	Unknown Code = 6
+)
+
+var (
+	statusText = map[Code]string{
+		OK:                "OK",
+		InvalidParameters: "Invalid Parameters",
+		SystemError:       "System Error",
+		ConnectionError:   "Connection Error",
+		DataUnavailable:   "Data Unavailable",
+		InvalidFile:       "Invalid File",
+		Unknown:           "Unknown",
+	}
+)
+
+// Text returns a text for a status code. It returns the empty
+// string if the code is unknown.
+func Text(code Code) string {
+	return statusText[code]
+}


### PR DESCRIPTION
Adicionando parcialmente o [Status Package](https://github.com/dadosjusbr/coletores/tree/master/status).

Olhando a forma como o [dadosjusbr/coletores/executor/main.go](https://github.com/dadosjusbr/coletores/blob/master/executor/main.go) utiliza o [Status Package](https://github.com/dadosjusbr/coletores/tree/master/status) (comparando os códigos de status e retornando a descrição de cada código.), acredito que os respectivos trechos de código podem ser adiconandos dentro do atual pacote executor.

O que acha?