### PR TITLE
Add result pipeline

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -83,8 +83,7 @@ func setup(repo, dir string) error {
 // Run executes the pipeline
 func (p *Pipeline) Run() (PipelineResult, error) {
 	now := time.Now()
-	var result PipelineResult
-	result = PipelineResult{Name: p.Name, Timestamp: now.Unix()}
+	result := PipelineResult{Name: p.Name, Timestamp: now.Unix()}
 
 	for index, stage := range p.Stages {
 		var ser StageExecutionResult

--- a/pipeline.go
+++ b/pipeline.go
@@ -176,11 +176,11 @@ func buildImage(id, dir string, buildEnv map[string]string) (CmdResult, error) {
 
 	log.Printf("$ %s", strings.Join(cmdList, " "))
 	err := cmd.Run()
-	if err != nil {
+	switch err.(type) {
+	case *exec.Error:
 		cmdResultError := CmdResult{
 			ExitStatus: statusCode(err),
 			Cmd:        strings.Join(cmdList, " "),
-			CmdDir:     dir,
 		}
 		return cmdResultError, fmt.Errorf("command was not executed correctly: %s", err)
 	}
@@ -237,11 +237,11 @@ func runImage(id, dir, stdout string, runEnv map[string]string) (CmdResult, erro
 
 	log.Printf("$ %s", strings.Join(cmdList, " "))
 	err = cmd.Run()
-	if err != nil {
+	switch err.(type) {
+	case *exec.Error:
 		cmdResultError := CmdResult{
 			ExitStatus: statusCode(err),
 			Cmd:        strings.Join(cmdList, " "),
-			CmdDir:     dir,
 		}
 		return cmdResultError, fmt.Errorf("command was not executed correctly: %s", err)
 	}

--- a/tutorial/main.go
+++ b/tutorial/main.go
@@ -43,6 +43,10 @@ func main() {
 			BuildEnv: collectBuildEnv,
 			RunEnv:   collectRunEnv,
 		},
+		{
+			Name: "Empacotador",
+			Dir:  "trt13",
+		},
 	}
 
 	_, err := p.Run()


### PR DESCRIPTION
**Passando o stdout do RunImage do estágio anterior para o RunImage do estágio corrente.**

Pensei em criar um array dos resultados de cada estágio para que eles possam ser compartilhados. Porém, ao observar a forma como build e run usavam e retornavam um (até então) *StageExecutionResult*  entendi que o *StageExecutionResult* não era o **resultado final do estágio** e sim dos comandos build e run. 

Pensando nisso, fiz a separação entre o que chamei de *CmdResult* e *StageExecutionResult*, onde no segundo existem as infomações *BuildResult* e *RunResult* mais o nome do estágio e informações referente ao inicio e fim do processamento do estágio (Achei que seriam informações interessantes, até pra talvez utilizar como métrica para o escalonamento das execuções. Mas se você não achar necessário, não tenho oposição em retirar).