### PR TITLE
Ajustes no Setup do Pipeline

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -14,26 +14,30 @@ import (
 	"github.com/dadosjusbr/executor/status"
 )
 
-const noExitError = -2
-const output = "output"
-const dirPermission = 0644
+const (
+	noExitError   = -2
+	output        = "output"
+	dirPermission = 0666
+	storeErrDir   = "store-error" // Refers to directory store-error of the dadosjusbr/coletores repository.
+)
 
 // Stage is a phase of data release process.
 type Stage struct {
-	Name     string
-	Dir      string
-	Repo     string
-	BuildEnv map[string]string
-	RunEnv   map[string]string
+	Name     string            // Stage's name.
+	Dir      string            // Directory to be concatenated with default repository or with the repository specified at the stage.
+	Repo     string            // Repository for the stage. This field overwrites the DefaultRepo in pipeline's definition.
+	BuildEnv map[string]string // Variables to be used in the stage build. They will be concatenated with the default variables defined in the pipeline, overwriting them if repeated.
+	RunEnv   map[string]string // Variables to be used in the stage run. They will be concatenated with the default variables defined in the pipeline, overwriting them if repeated.
 }
 
 // Pipeline represents the sequence of stages for data release.
 type Pipeline struct {
-	Name            string
-	DefaultRepo     string
-	DefaultBuildEnv map[string]string
-	DefaultRunEnv   map[string]string
-	Stages          []Stage
+	Name            string            // Pipeline's name.
+	DefaultRepo     string            // Default repository to be used in the run of all stages.
+	DefaultBuildEnv map[string]string // Default variables to be used in the build of all stages.
+	DefaultRunEnv   map[string]string // Default variables to be used in the run of all stages.
+	Stages          []Stage           // Confguration for the pipeline's stages.
+	StoreErrDir     string            // Directory containing the dockerize script for to store the stage error. If empty, the const storeErrDir will be used.
 }
 
 // CmdResult represents information about a execution of a command.
@@ -62,20 +66,27 @@ type PipelineResult struct {
 	StagesResults []StageExecutionResult `json:"stageResult" bson:"stageResult,omitempty"` // Results of stage execution.
 	StartTime     time.Time              `json:"start" bson:"start,omitempty"`             // Time at start of pipeline.
 	FinalTime     time.Time              `json:"final" bson:"final,omitempty"`             // Time at end of pipeline.
-	// Todo: checagem e atribuição de status
-	Status string `json:"status" bson:"status,omitempty"` // String to inform if the pipepine has finished with sucess or not.
+	Status        status.Code            `json:"status" bson:"status,omitempty"`           // String to inform if the pipepine has finished with sucess or not.
 }
 
-func setup(repo, dir string) error {
-	finalPath := fmt.Sprintf("%s/%s/%s", repo, dir, output)
-	if os.IsNotExist(os.Mkdir(finalPath, dirPermission)) {
-		if err := os.Mkdir(finalPath, os.ModeDir); err != nil {
-			return fmt.Errorf("error creating output folder: %q", err)
-		}
+func setup(repo string) error {
+	cmdList := strings.Split("docker volume rm -f dadosjusbr", " ")
+	cmd := exec.Command(cmdList[0], cmdList[1:]...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error removing existing volume dadosjusbr: %q", err)
 	}
 
-	cmdList := strings.Split(fmt.Sprintf("docker volume create --driver local --opt type=none --opt device=%s --opt o=bind --name=dadosjusbr", finalPath), " ")
-	cmd := exec.Command(cmdList[0], cmdList[1:]...)
+	finalPath := fmt.Sprintf("%s/%s", repo, output)
+	if err := os.RemoveAll(finalPath); err != nil {
+		return fmt.Errorf("error removing existing output folder: %q", err)
+	}
+
+	if err := os.Mkdir(finalPath, dirPermission); err != nil {
+		return fmt.Errorf("error creating output folder: %q", err)
+	}
+
+	cmdList = strings.Split(fmt.Sprintf("docker volume create --driver local --opt type=none --opt device=%s --opt o=bind --name=dadosjusbr", finalPath), " ")
+	cmd = exec.Command(cmdList[0], cmdList[1:]...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error creating volume dadosjusbr: %q", err)
 	}
@@ -83,62 +94,82 @@ func setup(repo, dir string) error {
 	return nil
 }
 
-// Run executes the pipeline
+// Run executes the pipeline.
 func (p *Pipeline) Run() (PipelineResult, error) {
 	result := PipelineResult{Name: p.Name, StartTime: time.Now()}
+
+	if err := setup(p.DefaultRepo); err != nil {
+		result.Status = status.SetupError
+		return result, fmt.Errorf("error in inicial setup. %q", err)
+	}
 
 	for index, stage := range p.Stages {
 		var ser StageExecutionResult
 		var err error
+		ser.Stage = stage.Name
+		ser.StartTime = time.Now()
 
 		if len(stage.Repo) == 0 {
 			stage.Repo = p.DefaultRepo
 		}
-		if err := setup(stage.Repo, stage.Dir); err != nil {
-			return PipelineResult{}, fmt.Errorf("error in inicial setup. %q", err)
-		}
+		dir := fmt.Sprintf("%s/%s", stage.Repo, stage.Dir)
 
 		id := fmt.Sprintf("%s/%s", p.Name, stage.Name)
+		// 'index+1' because the index starts from 0.
 		log.Printf("Executing Pipeline %s [%d/%d]\n", id, index+1, len(p.Stages))
-
-		ser.Stage = stage.Name
-		ser.StartTime = time.Now()
-		dir := fmt.Sprintf("%s/%s", stage.Repo, stage.Dir)
 
 		stage.BuildEnv = mergeEnv(p.DefaultBuildEnv, stage.BuildEnv)
 		ser.BuildResult, err = buildImage(id, dir, stage.BuildEnv)
 		if err != nil {
-			storeError("error when building image", err)
+			ser.FinalTime = time.Now()
+			result.StagesResults = append(result.StagesResults, ser)
+			result.Status = status.BuildError
+			result.FinalTime = time.Now()
+			return result, fmt.Errorf("error when building image: %s", err)
 		}
 		if status.Code(ser.BuildResult.ExitStatus) != status.OK {
-			storeError("error when building image", fmt.Errorf("Status code %d(%s) when building image for %s", ser.BuildResult.ExitStatus, status.Text(status.Code(ser.BuildResult.ExitStatus)), id))
+			ser.FinalTime = time.Now()
+			result.StagesResults = append(result.StagesResults, ser)
+			result.Status = status.BuildError
+			result.FinalTime = time.Now()
+			return result, fmt.Errorf("error when building image: status code %d(%s) when building image for %s", ser.BuildResult.ExitStatus, status.Text(status.Code(ser.BuildResult.ExitStatus)), id)
 		}
 
 		stdout := ""
 		if index != 0 {
+			// 'index-1' is accessing the output from previous stage.
 			stdout = result.StagesResults[index-1].RunResult.Stdout
 		}
 
 		stage.RunEnv = mergeEnv(p.DefaultRunEnv, stage.RunEnv)
 		ser.RunResult, err = runImage(id, dir, stdout, stage.RunEnv)
 		if err != nil {
-			storeError("error when running image", err)
+			ser.FinalTime = time.Now()
+			result.StagesResults = append(result.StagesResults, ser)
+			result.Status = status.BuildError
+			result.FinalTime = time.Now()
+			return result, fmt.Errorf("error when running image: %s", err)
 		}
 		if status.Code(ser.RunResult.ExitStatus) != status.OK {
-			storeError("error when running image", fmt.Errorf("Status code %d(%s) when running image for %s", ser.RunResult.ExitStatus, status.Text(status.Code(ser.RunResult.ExitStatus)), id))
+			ser.FinalTime = time.Now()
+			result.StagesResults = append(result.StagesResults, ser)
+			result.Status = status.BuildError
+			result.FinalTime = time.Now()
+			return result, fmt.Errorf("error when running image: Status code %d(%s) when running image for %s", ser.RunResult.ExitStatus, status.Text(status.Code(ser.RunResult.ExitStatus)), id)
 		}
 
 		ser.FinalTime = time.Now()
 		result.StagesResults = append(result.StagesResults, ser)
 	}
 
+	result.Status = status.OK
 	result.FinalTime = time.Now()
 	return result, nil
 }
 
 func storeError(msg string, err error) error {
 	return fmt.Errorf("%s: %s", msg, err)
-	// TODO: Store error
+	// TODO: store error
 	//er.Cr.AgencyID = filepath.Base(job)
 	//Store Error
 	//Build(storeErrDir, commit, conf)
@@ -223,12 +254,12 @@ func runImage(id, dir, stdout string, runEnv map[string]string) (CmdResult, erro
 
 	var builder strings.Builder
 	for key, value := range runEnv {
-		fmt.Fprintf(&builder, "%s=%s ", key, value)
+		fmt.Fprintf(&builder, "--env %s=%s ", key, value)
 	}
 	env := strings.TrimRight(builder.String(), " ")
 
-	cmdList := strings.Split(fmt.Sprintf("docker run -i -v dadosjusbr:/output --rm %s %s", filepath.Base(dir), env), " ")
-	cmd := exec.Command("docker", cmdList...)
+	cmdList := strings.Split(fmt.Sprintf("docker run -i -v dadosjusbr:/output --rm %s %s", env, filepath.Base(dir)), " ")
+	cmd := exec.Command(cmdList[0], cmdList[1:]...)
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(string(stdoutJSON))
 	var outb, errb bytes.Buffer

--- a/pipeline.go
+++ b/pipeline.go
@@ -64,7 +64,7 @@ type PipelineResult struct {
 	StagesResults []StageExecutionResult `json:"stageResult" bson:"stageResult,omitempty"` // Results of stage execution.
 	StartTime     time.Time              `json:"start" bson:"start,omitempty"`             // Time at start of pipeline.
 	FinalTime     time.Time              `json:"final" bson:"final,omitempty"`             // Time at end of pipeline.
-	Status        status.Code            `json:"status" bson:"status,omitempty"`           // String to inform if the pipepine has finished with sucess or not.
+	Status        status.Code            `json:"status" bson:"status,omitempty"`           // Pipeline execution status(OK, RunError, BuildError, SetupError).
 }
 
 func setup(repo string) error {

--- a/pipeline.go
+++ b/pipeline.go
@@ -18,7 +18,6 @@ const (
 	noExitError   = -2
 	output        = "output"
 	dirPermission = 0666
-	storeErrDir   = "store-error" // Refers to directory store-error of the dadosjusbr/coletores repository.
 )
 
 // Stage is a phase of data release process.
@@ -37,7 +36,6 @@ type Pipeline struct {
 	DefaultBuildEnv map[string]string // Default variables to be used in the build of all stages.
 	DefaultRunEnv   map[string]string // Default variables to be used in the run of all stages.
 	Stages          []Stage           // Confguration for the pipeline's stages.
-	StoreErrDir     string            // Directory containing the dockerize script for to store the stage error. If empty, the const storeErrDir will be used.
 }
 
 // CmdResult represents information about a execution of a command.
@@ -169,7 +167,7 @@ func (p *Pipeline) Run() (PipelineResult, error) {
 
 func storeError(msg string, err error) error {
 	return fmt.Errorf("%s: %s", msg, err)
-	// TODO: store error
+	// TODO: Store error
 	//er.Cr.AgencyID = filepath.Base(job)
 	//Store Error
 	//Build(storeErrDir, commit, conf)

--- a/status/status.go
+++ b/status/status.go
@@ -24,6 +24,15 @@ const (
 
 	// Unknown means that something unexpected has happend
 	Unknown Code = 6
+
+	// SetupError errors should be used for scenarios with setup problemns, like fail on create the volume for containers.
+	SetupError Code = 7
+
+	// BuildError errors should be used for scenarios with 'docker build' problemns.
+	BuildError Code = 8
+
+	// RunError errors should be used for scenarios with 'docker run' problemns.
+	RunError Code = 9
 )
 
 var (


### PR DESCRIPTION
Esse PR trata de alguns ajustes no setup e finalização da execução do Pipeline quando encontrar um erro no `buildImage` ou `runImage`. Os ajustes realizados, de forma mais detalhada, foram:

- Adicionando descrições aos campos de configuração do pipeline.
- Alterando a função `setup` para remover a pasta output e o volume dadosjusbr antes de recriá-los.
- Retirando a chamada do `setup` de dentro do for.
- Corrigindo a concatenação do comando 'docker run'.
- Retornando o `PipelineResult` ao encontrar erros no `buildImage` ou `runImage`.

