### PR TITLE
Usando o pacote Status no pipeline.go

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -108,7 +108,7 @@ func tearDown() error {
 // case of an error in the pipeline standard flow, which is when we call the
 // function handleError.
 //
-// When handleError is called we pass all information about the pipeline
+// When handleError is called we pass all informations about the pipeline
 // execution until that point, which are:
 // - the PipelineResult (until current stage),
 // - the StageResult (from current stage),
@@ -198,7 +198,7 @@ func (p *Pipeline) Run() (PipelineResult, error) {
 // defined, the default behavior is to return the PipelineResult until
 // the last stage executed and the error occurred.
 //
-// When handleError is called it receives all information about the pipeline
+// When handleError is called it receives all informations about the pipeline
 // execution until that point, which are:
 // - the PipelineResult (until current stage),
 // - the StageResult (from current stage),

--- a/pipeline.go
+++ b/pipeline.go
@@ -223,7 +223,7 @@ func handleError(result *PipelineResult, previousSer StageExecutionResult, previ
 			return *result, status.NewError(status.BuildError, fmt.Errorf("error when building image for error handler: Status code %d(%s) when running image for %s", serError.BuildResult.ExitStatus, status.Text(status.Code(serError.BuildResult.ExitStatus)), id))
 		}
 
-		serError.RunResult, err = runImage(id, handler.Dir, status.Text(previousStatus), handler.RunEnv)
+		serError.RunResult, err = runImage(id, handler.Dir, previousSer.RunResult.Stdout, handler.RunEnv)
 		if err != nil {
 			result.StageResults = append(result.StageResults, serError)
 			result.Status = status.Text(status.ErrorHandlerError)

--- a/pipeline.go
+++ b/pipeline.go
@@ -60,11 +60,11 @@ type StageExecutionResult struct {
 
 // PipelineResult represents the pipeline information and their results.
 type PipelineResult struct {
-	Name          string                 `json:"name" bson:"name,omitempty"`               // Name of pipeline.
-	StagesResults []StageExecutionResult `json:"stageResult" bson:"stageResult,omitempty"` // Results of stage execution.
-	StartTime     time.Time              `json:"start" bson:"start,omitempty"`             // Time at start of pipeline.
-	FinalTime     time.Time              `json:"final" bson:"final,omitempty"`             // Time at end of pipeline.
-	Status        string                 `json:"status" bson:"status,omitempty"`           // Pipeline execution status(OK, RunError, BuildError, SetupError...).
+	Name         string                 `json:"name" bson:"name,omitempty"`               // Name of pipeline.
+	StageResults []StageExecutionResult `json:"stageResult" bson:"stageResult,omitempty"` // Results of stage execution.
+	StartTime    time.Time              `json:"start" bson:"start,omitempty"`             // Time at start of pipeline.
+	FinalTime    time.Time              `json:"final" bson:"final,omitempty"`             // Time at end of pipeline.
+	Status       string                 `json:"status" bson:"status,omitempty"`           // Pipeline execution status(OK, RunError, BuildError, SetupError...).
 }
 
 func setup(baseDir string) error {

--- a/status/go.mod
+++ b/status/go.mod
@@ -1,3 +1,0 @@
-module github.com/dadosjusbr/executor/status
-
-go 1.13

--- a/tutorial/stage-go/main.go
+++ b/tutorial/stage-go/main.go
@@ -25,6 +25,9 @@ func main() {
 		log.Fatal(status.DataUnavailable)
 		status.ExitFromError(status.NewError(status.DataUnavailable, fmt.Errorf("error requesting url: %s", err)))
 	}
+	if resp.StatusCode != 200 {
+		log.Fatalf("http status is not 200 OK. request returned the %d status", resp.StatusCode)
+	}
 	defer resp.Body.Close()
 
 	data, err := ioutil.ReadAll(resp.Body)

--- a/tutorial/stage-go/main.go
+++ b/tutorial/stage-go/main.go
@@ -25,9 +25,6 @@ func main() {
 		log.Fatal(status.DataUnavailable)
 		status.ExitFromError(status.NewError(status.DataUnavailable, fmt.Errorf("error requesting url: %s", err)))
 	}
-	if resp.StatusCode != 200 {
-		log.Fatalf("http status is not 200 OK. request returned the %d status", resp.StatusCode)
-	}
 	defer resp.Body.Close()
 
 	data, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
- Utilizando o pacote status ao retornaros erros no pipeline.go;
- Mudando a utilização do código do status para o texto do status, para facilitar a leitura do ResultPipeline.